### PR TITLE
Update network configuration for 3.10 release

### DIFF
--- a/vagrant/scripts/setup-aerospike-config.sh
+++ b/vagrant/scripts/setup-aerospike-config.sh
@@ -32,12 +32,15 @@ function setupAerospike {
 	echo "    }" >> /etc/aerospike/aerospike.conf
 	echo "}" >> /etc/aerospike/aerospike.conf
 
+	echo "service {" >> /etc/aerospike/aerospike.conf
+	echo "node-id-interface eth2" >> /etc/aerospike/aerospike.conf
+	echo "}" >> /etc/aerospike/aerospike.conf
+
 	echo "network {" >> /etc/aerospike/aerospike.conf
 	echo "	service {" >> /etc/aerospike/aerospike.conf
 	echo "		address any" >> /etc/aerospike/aerospike.conf
 	echo "		port 3000" >> /etc/aerospike/aerospike.conf
 	echo "		access-address ${IP_PREFIX}${NODE} virtual" >> /etc/aerospike/aerospike.conf
-	echo "		network-interface-name eth2" >> /etc/aerospike/aerospike.conf
 	echo "		}" >> /etc/aerospike/aerospike.conf
 	echo "	heartbeat {" >> /etc/aerospike/aerospike.conf
 	echo "		mode mesh" >> /etc/aerospike/aerospike.conf


### PR DESCRIPTION
Vagrant up is failing due to changes in https://www.aerospike.com/docs/operations/upgrade/network_to_3_10
Error:
    node2: Starting and checking aerospike:
    node2: May 22 2018 09:40:53 GMT: FAILED ASSERTION (config): (cfg.c:1526) line 33 :: 'network-interface-name' is obsolete - see Aerospike documentation http://www.aerospike.com/docs/operations/upgrade/network_to_3_10
    node2: May 22 2018 09:40:53 GMT: WARNING (as): (signal.c:145) SIGINT received, shutting down
    node2: May 22 2018 09:40:53 GMT: WARNING (as): (signal.c:148) startup was not complete, exiting immediately
    node2: [FAILED]
