### PR TITLE
Fix configurations in start_aerospike.conf

### DIFF
--- a/intro/start_aerospike.conf
+++ b/intro/start_aerospike.conf
@@ -6,8 +6,6 @@ service {
 	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
 	pidfile /var/run/aerospike/asd.pid
 	service-threads 4
-	transaction-queues 4
-	transaction-threads-per-queue 4
 	proto-fd-max 15000
 }
 
@@ -57,7 +55,7 @@ network {
 namespace test {
         replication-factor 2
         memory-size 2G
-        default-ttl 5d # 5 days, use 0 to never expire/evict.
+        default-ttl 0 # 0 to never expire/evict.
 
         # To use file storage backing, comment out the line above and use the
         # following lines instead.


### PR DESCRIPTION
Current configuration no longer brings up the aerospike server. Two of the config params are obsolete and one of the params causes failure. Here are some error logs that I saw

```
Starting and checking aerospike: Jun 24 2020 23:43:19 GMT: CRITICAL (config): (cfg.c:1409) line 9 :: 'transaction-threads-per-queue' is obsolete - please configure 'service-threads' carefully
Starting and checking aerospike: Jun 24 2020 23:44:45 GMT: CRITICAL (config): (cfg.c:2977) {test} must configure non-zero 'nsup-period' or 'allow-ttl-without-nsup' true if 'default-ttl' is non-zero
Jun 24 2020 23:44:45 GMT: WARNING (as): (signal.c:161) SIGINT received, shutting down Aerospike Community Edition build 5.0.0.7 os el6
Jun 24 2020 23:44:45 GMT: WARNING (as): (signal.c:164) startup was not complete, exiting immediately
```